### PR TITLE
[HyeonJun] History Update API 대응 및 구현

### DIFF
--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryDetailActivity.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryDetailActivity.kt
@@ -1,5 +1,6 @@
 package com.haerokim.project_footprint.Activity
 
+import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
@@ -10,6 +11,15 @@ import com.haerokim.project_footprint.R
 import kotlinx.android.synthetic.main.activity_history_detail.*
 
 class HistoryDetailActivity : AppCompatActivity() {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        // 수정된 정보가 넘어오면 실행
+        if(requestCode == 1 && resultCode == Activity.RESULT_OK){
+            text_history_detail_title.text = data?.getStringExtra("title")
+            text_history_detail_content.text = data?.getStringExtra("comment")
+//            TODO ("나머지 2개 Extra 미구현")
+        }
+    }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_history_detail)
@@ -51,7 +61,7 @@ class HistoryDetailActivity : AppCompatActivity() {
                         val intent = Intent(this, HistoryEditActivity::class.java)
                         intent.putExtras(historyInfo!!)
                         intent.setFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-                        startActivity(intent)
+                        startActivityForResult(intent, 1)
 //                        overridePendingTransition(R.anim.fadein, R.anim.fadeout)
                     }
 

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryEditActivity.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryEditActivity.kt
@@ -1,12 +1,27 @@
 package com.haerokim.project_footprint.Activity
 
+import android.app.Activity
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.DialogInterface
+import android.content.Intent
+import android.content.SharedPreferences
+import android.graphics.Color
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import com.bumptech.glide.Glide
+import com.google.gson.GsonBuilder
+import com.haerokim.project_footprint.DataClass.History
+import com.haerokim.project_footprint.DataClass.UpdateHistory
+import com.haerokim.project_footprint.Network.RetrofitService
+import com.haerokim.project_footprint.Network.Website
 import com.haerokim.project_footprint.R
+import io.paperdb.Paper
 import kotlinx.android.synthetic.main.activity_history_detail.*
 import kotlinx.android.synthetic.main.activity_history_detail.history_detail_image
 import kotlinx.android.synthetic.main.activity_history_detail.text_history_detail_content
@@ -14,8 +29,15 @@ import kotlinx.android.synthetic.main.activity_history_detail.text_history_detai
 import kotlinx.android.synthetic.main.activity_history_detail.text_history_detail_time
 import kotlinx.android.synthetic.main.activity_history_detail.text_history_detail_title
 import kotlinx.android.synthetic.main.activity_history_edit.*
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
 
 class HistoryEditActivity : AppCompatActivity() {
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_history_edit)
@@ -31,6 +53,18 @@ class HistoryEditActivity : AppCompatActivity() {
         var historyCreatedAt = historyInfo?.getString("createdAt") ?: "어느 멋진 날"
         var historyUserID = historyInfo?.getInt("userID")
 
+        val gson = GsonBuilder()
+            .setDateFormat("yyyy-MM-dd")
+            .create()
+
+        var retrofit = Retrofit.Builder()
+            .baseUrl(Website.BASE_URL) //사이트 Base URL
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+
+        var updateHistoryService: RetrofitService =
+            retrofit.create(RetrofitService::class.java)
+
         if (historyImage == null) {
             // Image URL 없을 시 기본 이미지
             history_detail_image.setImageResource(R.drawable.placeholder)
@@ -42,7 +76,7 @@ class HistoryEditActivity : AppCompatActivity() {
                 .into(history_detail_image)
         }
 
-        text_history_detail_title.text = historyTitle
+        edit_history_detail_title.setText(historyTitle)
         edit_history_detail_place.text = historyPlaceTitle
         edit_history_detail_time.text = historyCreatedAt
         edit_history_detail_content.setText(historyComment)
@@ -72,7 +106,58 @@ class HistoryEditActivity : AppCompatActivity() {
 
                     }
                 }
+//                TODO("Spinner 메뉴 (기분) Int 값 Django History 모델과 조율 필요")
             }
+        }
+
+        button_save_history.setOnClickListener {
+            historyTitle = edit_history_detail_title.text.toString()
+            historyComment = edit_history_detail_content.text.toString()
+            val builder: AlertDialog.Builder =
+                AlertDialog.Builder(this)
+            builder.setTitle("편집하기")
+            builder.setMessage("모두 작성하셨나요?")
+            builder.setPositiveButton("예",
+                DialogInterface.OnClickListener { dialog, which ->
+                    val updateHistory =
+                        UpdateHistory(historyImage, historyTitle, historyMood, historyComment)
+                    updateHistoryService.updateHistory(historyID!!, updateHistory)
+                        .enqueue(object : Callback<History> {
+                            override fun onFailure(call: Call<History>, t: Throwable) {
+                                Log.e("Update History Error", t.message)
+                            }
+
+                            override fun onResponse(
+                                call: Call<History>,
+                                response: Response<History>
+                            ) {
+                                Log.d("Update History", "History 수정 완료")
+
+                                val resultHistory = response.body()
+                                val intent = Intent()
+
+                                intent.putExtra("image", resultHistory?.img)
+                                intent.putExtra("title", resultHistory?.title)
+                                intent.putExtra("mood", resultHistory?.mood)
+                                intent.putExtra("comment", resultHistory?.comment)
+
+                                setResult(Activity.RESULT_OK, intent)
+                                finish()
+                            }
+                        })
+                })
+            builder.setNegativeButton("아니오",
+                DialogInterface.OnClickListener { dialog, which ->
+                })
+            val alertDialog = builder.create()
+            alertDialog.show()
+            val view: ViewGroup.MarginLayoutParams =
+                alertDialog.getButton(Dialog.BUTTON_POSITIVE).layoutParams as ViewGroup.MarginLayoutParams
+            view.leftMargin = 16
+            alertDialog.getButton(Dialog.BUTTON_NEGATIVE)
+                .setBackgroundColor(Color.parseColor("#e8e8e8"))
+            alertDialog.getButton(Dialog.BUTTON_NEGATIVE)
+                .setTextColor(Color.parseColor("#000000"))
         }
     }
 }

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Adapter/HistoryListAdapter.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Adapter/HistoryListAdapter.kt
@@ -60,14 +60,19 @@ class HistoryListAdapter(
             intent.putExtras(bundle)
             context.startActivity(intent)
         }
-        holder.view.text_history_title.text = historyList[position].title ?: "탭 하여 작성하기"
+        holder.view.text_history_title.text = historyList[position].title ?: historyList[position].place + "에서의 추억"
         holder.view.text_history_detail.text =
             historyList[position].place + "에서, " + historyCreatedAt
-        Glide.with(holder.view) // 확인 필요
-            .load("https://images.unsplash.com/photo-1455894127589-22f75500213a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1579&q=80")
-            .centerCrop()
-            .override(600, 400)
-            .thumbnail(0.1f)
-            .into(holder.view.image_history)
+
+        if(historyList[position].img == null){
+            holder.view.image_history.visibility = View.GONE
+        }else{
+            Glide.with(holder.view) // 확인 필요
+                .load(historyList[position].img)
+                .centerCrop()
+                .override(600, 400)
+                .thumbnail(0.1f)
+                .into(holder.view.image_history)
+        }
     }
 }

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/DataClass/UpdateHistory.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/DataClass/UpdateHistory.kt
@@ -1,0 +1,8 @@
+package com.haerokim.project_footprint.DataClass
+
+class UpdateHistory(
+    val img:String?,
+    val title:String?,
+    val mood:String?,
+    val comment:String?
+)

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/RetrofitService.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/RetrofitService.kt
@@ -6,6 +6,9 @@ import retrofit2.http.*
 import kotlin.collections.ArrayList
 
 interface RetrofitService {
+
+    /** 대응 완료 API**/
+
     // 로그인
     @FormUrlEncoded
     @POST("api/v1/accounts/login/")
@@ -71,6 +74,15 @@ interface RetrofitService {
         @Query("title__icontains") keyword: String
     ): Call<ArrayList<History>>
 
+    // 히스토리 수정
+    @PUT("api/histories/{historyID}/edit/")
+    fun updateHistory(
+        @Path("historyID") historyID: Int,
+        @Body body: UpdateHistory
+    ): Call<History>
+
+    /** 미 대응 API**/
+
     @Multipart
     // History Image Upload
 
@@ -81,12 +93,6 @@ interface RetrofitService {
         @Field("userID") userID: Int
     ): Call<String> //Response : Status Code
 
-    // 히스토리 작성 및 수정 : 수정 예정
-    @FormUrlEncoded
-    @PUT("/api/diary-write")
-    fun writeHistory(
-        @Field("history") history: History
-    ): Call<String> //Response : Status Code
 
     // 히스토리 삭제 : 수정 예정
     @FormUrlEncoded

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/Website.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/Website.kt
@@ -2,6 +2,6 @@ package com.haerokim.project_footprint.Network
 
 class Website {
     companion object{
-        const val BASE_URL = "http://f87cffde35ea.ngrok.io"
+        const val BASE_URL = "http://6279a4d01e76.ngrok.io"
     }
 }

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/ui/history/DateHistoryFragment.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/ui/history/DateHistoryFragment.kt
@@ -39,6 +39,9 @@ class DateHistoryFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        // Realm을 활용해 장소의 정보를 Local에 저장하게 됨
+        Realm.init(context)
+
         // Inflate the layout for this fragment
         return inflater.inflate(R.layout.fragment_date_history, container, false)
     }
@@ -47,8 +50,7 @@ class DateHistoryFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         text_date_no_data.visibility = View.GONE
 
-        // Realm을 활용해 장소의 정보를 Local에 저장하게 됨
-        Realm.init(context)
+
         val config: RealmConfiguration = RealmConfiguration.Builder()
             .deleteRealmIfMigrationNeeded()
             .build()

--- a/Application/Project_Footprint/app/src/main/res/layout/activity_history_edit.xml
+++ b/Application/Project_Footprint/app/src/main/res/layout/activity_history_edit.xml
@@ -75,7 +75,7 @@
 
 
                 <EditText
-                    android:id="@+id/text_history_detail_title"
+                    android:id="@+id/edit_history_detail_title"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_centerVertical="true"

--- a/Application/Project_Footprint/app/src/main/res/layout/history_item.xml
+++ b/Application/Project_Footprint/app/src/main/res/layout/history_item.xml
@@ -13,11 +13,11 @@
         app:cardCornerRadius="16dp"
         android:id="@+id/card_view"
         android:layout_width="match_parent"
-        android:layout_height="280dp"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_gravity="center"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="6dp"
         app:cardElevation="0dp"
         android:layout_marginBottom="8dp">
 


### PR DESCRIPTION
- history_item.xml : 이미지를 등록하지 않은 History는 Image 레이아웃을 감추도록 변경했습니다.
- HistoryDetailActivity.kt : 메뉴 버튼을 누르면 3가지 메뉴 (편집, 공유, 삭제)가 뜨도록 구현했습니다.
- HistoryEditActivity.kt : History의 내용을 변경하고 서버에 수정요청하는 기능을 구현했습니다.
- UpdateHistory.kt : 수정 요청을 위한 Body Class를 만들었습니다.