### PR TITLE
[HyeonJun] History 수정 시 Image 업로드 안하는 상황 대응

### DIFF
--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryEditActivity.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryEditActivity.kt
@@ -18,6 +18,7 @@ import com.bumptech.glide.Glide
 import com.google.gson.GsonBuilder
 import com.haerokim.project_footprint.DataClass.History
 import com.haerokim.project_footprint.DataClass.UpdateHistory
+import com.haerokim.project_footprint.DataClass.UpdateHistoryNoImage
 import com.haerokim.project_footprint.Network.RetrofitService
 import com.haerokim.project_footprint.Network.Website
 import com.haerokim.project_footprint.R
@@ -112,47 +113,76 @@ class HistoryEditActivity : AppCompatActivity() {
             historyTitle = edit_history_detail_title.text.toString()
             historyComment = edit_history_detail_content.text.toString()
 
-
             val builder: AlertDialog.Builder =
                 AlertDialog.Builder(this)
             builder.setTitle("편집하기")
             builder.setMessage("모두 작성하셨나요?")
             builder.setPositiveButton("예",
                 DialogInterface.OnClickListener { dialog, which ->
-                    val updateHistory =
-                        UpdateHistory(historyImage, historyTitle, historyMood, historyComment)
-                    updateHistoryService.updateHistory(historyID!!, updateHistory)
-                        .enqueue(object : Callback<History> {
-                            override fun onFailure(call: Call<History>, t: Throwable) {
-                                Log.e("Update History Error", t.message)
-                            }
 
-                            override fun onResponse(
-                                call: Call<History>,
-                                response: Response<History>
-                            ) {
-                                if(response.code() == 400){
-                                    Log.d("Error", historyImage)
-                                    Log.d("Error", historyTitle)
-                                    Log.d("Error", historyMood)
-                                    Log.d("Error", historyComment)
-                                    Log.e("Update History Error", response.message())
-                                }else{
-                                    Log.d("Update History", "History 수정 완료")
+                    // 이미지 수정을 하지 않았을 때 다른 메소드 호출함
+                    if(historyImage == historyInfo?.getString("image")) {
+                        val updateHistory =
+                            UpdateHistoryNoImage(historyTitle, historyMood, historyComment)
+                        updateHistoryService.updateHistoryWithoutImage(historyID!!, updateHistory)
+                            .enqueue(object : Callback<History> {
+                                override fun onFailure(call: Call<History>, t: Throwable) {
+                                    Log.e("Update History Error", t.message)
 
-                                    val resultHistory = response.body()
-                                    val intent = Intent()
-
-                                    intent.putExtra("image", resultHistory?.img)
-                                    intent.putExtra("title", resultHistory?.title)
-                                    intent.putExtra("mood", resultHistory?.mood)
-                                    intent.putExtra("comment", resultHistory?.comment)
-
-                                    setResult(Activity.RESULT_OK, intent)
-                                    finish()
                                 }
-                            }
-                        })
+                                override fun onResponse(
+                                    call: Call<History>,
+                                    response: Response<History>
+                                ) {
+                                    if(response.code() == 400){
+                                        Log.e("Update History Error", response.message())
+                                    }else{
+                                        Log.d("Update History", "History 수정 완료")
+
+                                        val resultHistory = response.body()
+                                        val intent = Intent()
+
+                                        intent.putExtra("image", resultHistory?.img)
+                                        intent.putExtra("title", resultHistory?.title)
+                                        intent.putExtra("mood", resultHistory?.mood)
+                                        intent.putExtra("comment", resultHistory?.comment)
+
+                                        setResult(Activity.RESULT_OK, intent)
+                                        finish()
+                                    }
+                                }
+                            })
+                    }else{
+                        val updateHistory =
+                            UpdateHistory(historyImage, historyTitle, historyMood, historyComment)
+                        updateHistoryService.updateHistory(historyID!!, updateHistory)
+                            .enqueue(object : Callback<History> {
+                                override fun onFailure(call: Call<History>, t: Throwable) {
+                                    Log.e("Update History Error", t.message)
+                                }
+                                override fun onResponse(
+                                    call: Call<History>,
+                                    response: Response<History>
+                                ) {
+                                    if(response.code() == 400){
+                                        Log.e("Update History Error", response.message())
+                                    }else{
+                                        Log.d("Update History", "History 수정 완료")
+
+                                        val resultHistory = response.body()
+                                        val intent = Intent()
+
+                                        intent.putExtra("image", resultHistory?.img)
+                                        intent.putExtra("title", resultHistory?.title)
+                                        intent.putExtra("mood", resultHistory?.mood)
+                                        intent.putExtra("comment", resultHistory?.comment)
+
+                                        setResult(Activity.RESULT_OK, intent)
+                                        finish()
+                                    }
+                                }
+                            })
+                    }
                 })
             builder.setNegativeButton("아니오",
                 DialogInterface.OnClickListener { dialog, which ->

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/DataClass/UpdateHistoryNoImage.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/DataClass/UpdateHistoryNoImage.kt
@@ -1,0 +1,7 @@
+package com.haerokim.project_footprint.DataClass
+
+class UpdateHistoryNoImage (
+    val title:String?,
+    val mood:String?,
+    val comment:String?
+)

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/RetrofitService.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/RetrofitService.kt
@@ -81,6 +81,13 @@ interface RetrofitService {
         @Body body: UpdateHistory
     ): Call<History>
 
+    // 히스토리 수정
+    @PUT("api/histories/{historyID}/edit/")
+    fun updateHistoryWithoutImage(
+        @Path("historyID") historyID: Int,
+        @Body body: UpdateHistoryNoImage
+    ): Call<History>
+
     @GET("api/noticelist/")
     fun requestNoticeList(): Call<ArrayList<Notice>>
 
@@ -109,6 +116,7 @@ interface RetrofitService {
         @Path("historyID") historyID: Int
     ): Call<String>
 
+    // 임의 히스토리 생성
     @POST("/api/histories/")
     fun writeHistory(
         @Body history: WriteHistory


### PR DESCRIPTION
- HistoryEditActivity.kt : History를 수정할 때, Image를 기존 데이터 그대로 사용할 시 네트워크 작업 낭비 현상이 발생하기 때문에 Image 데이터가 변하지 않으면 다른 메소드를 호출하여 서버 업로드 작업을 하지 않도록 구현했습니다.
- UpdateHistoryNoImage.kt : 위 기능을 위한 데이터 클래스를 정의하였습니다.