### PR TITLE
[HyeonJun] 인스타그램 피드, 스토리 게시글 공유 기능 구현

### DIFF
--- a/Application/Project_Footprint/app/src/main/AndroidManifest.xml
+++ b/Application/Project_Footprint/app/src/main/AndroidManifest.xml
@@ -31,6 +31,18 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.haerokim.project_footprint"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
+
+
         <activity android:name=".Activity.HistoryWriteActivity"></activity>
         <activity android:name=".Activity.PasswordResetActivity" />
         <activity android:name=".Activity.RegisterConfirmActivity" />

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryDetailActivity.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Activity/HistoryDetailActivity.kt
@@ -6,27 +6,26 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.view.ViewGroup
 import android.widget.PopupMenu
 import android.widget.Toast
-import androidx.fragment.app.Fragment
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
 import com.bumptech.glide.Glide
 import com.google.gson.GsonBuilder
-import com.haerokim.project_footprint.DataClass.History
-import com.haerokim.project_footprint.DataClass.UpdateHistory
+import com.haerokim.project_footprint.Network.ImageDownloader
 import com.haerokim.project_footprint.Network.RetrofitService
 import com.haerokim.project_footprint.Network.Website
 import com.haerokim.project_footprint.R
-import com.haerokim.project_footprint.ui.history.WholeHistoryFragment
 import kotlinx.android.synthetic.main.activity_history_detail.*
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.io.File
 
 class HistoryDetailActivity : AppCompatActivity() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -95,7 +94,39 @@ class HistoryDetailActivity : AppCompatActivity() {
                     }
 
                     R.id.share_history -> {
+                        var sns = arrayOf("인스타그램 피드", "인스타그램 스토리", "페이스북 피드")
+                        val alertDialog = AlertDialog.Builder(this, android.R.style.Theme_DeviceDefault_Light_Dialog_Alert)
+                        alertDialog.setTitle("SNS 공유하기")
+                            .setItems(sns, DialogInterface.OnClickListener { dialog, which ->
+                                when(which){
+                                    0->{  // 인스타그램 피드
+                                        val snsIntent = Intent(Intent.ACTION_SEND)
+                                        val localPath: String = ImageDownloader().execute(historyImage).get()
+                                        val uri = FileProvider.getUriForFile(applicationContext, "com.haerokim.project_footprint", File(localPath))
 
+                                        snsIntent.setPackage("com.instagram.android")
+                                        snsIntent.setType("image/*")
+                                        snsIntent.putExtra(Intent.EXTRA_STREAM, uri)
+                                        startActivity(snsIntent)
+                                    }
+                                    1->{  // 인스타그램 스토리
+                                        val snsIntent = Intent("com.instagram.share.ADD_TO_STORY")
+                                        val localPath: String = ImageDownloader().execute(historyImage).get()
+                                        val uri = FileProvider.getUriForFile(applicationContext, "com.haerokim.project_footprint", File(localPath))
+                                        snsIntent.setType("image/*")
+                                        snsIntent.putExtra("top_background_color", "#e8e8e8")
+                                        snsIntent.putExtra("bottom_background_color", "#e8e8e8")
+                                        snsIntent.putExtra("interactive_asset_uri", uri)
+                                        this.grantUriPermission("com.instagram.android", uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        this.startActivityForResult(snsIntent, 0)
+                                    }
+                                    2->{  // 페이스북 피드
+
+                                    }
+                                }
+                            })
+                            .setCancelable(true)
+                            .show()
                     }
 
                     R.id.delete_history -> {

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/ImageDownloader.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/ImageDownloader.kt
@@ -1,0 +1,61 @@
+package com.haerokim.project_footprint.Network
+
+import android.content.Intent
+import android.net.Uri
+import android.os.AsyncTask
+import android.os.Environment
+import androidx.core.content.ContextCompat.startActivity
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+
+class ImageDownloader : AsyncTask<String, Void, String>() {
+    var fileName: String = "footprint"
+    val SAVE_FOLDER: String = "/footprint"
+    override fun doInBackground(vararg params: String): String {
+        val savePath = Environment.getExternalStorageDirectory().toString() + SAVE_FOLDER
+        val fileDir = File(savePath)
+        if (!fileDir.exists()) {
+            fileDir.mkdir()
+        }
+        val fileUrl = params[0]
+        val localPath = "$savePath/$fileName.jpg"
+
+        if (File(savePath + "/" + fileName).exists() == false) {  // 중복 다운로드가 아닐 경우
+            try {
+                val imgUrl = URL(fileUrl)
+                val connection: HttpURLConnection = imgUrl.openConnection() as HttpURLConnection
+                val len: Int = connection.contentLength
+                val tmpByte = ByteArray(len)
+                //입력 스트림을 구한다
+                val inputStream: InputStream = connection.inputStream
+                val file = File(localPath)
+                //파일 저장 스트림 생성
+                val fos = FileOutputStream(file)
+                var read: Int
+                //입력 스트림을 파일로 저장
+                while (true) {
+                    read = inputStream.read(tmpByte)
+                    if (read <= 0) {
+                        break
+                    }
+                    fos.write(tmpByte, 0, read) //file 생성
+                }
+                inputStream.close()
+                fos.close()
+                connection.disconnect()
+
+                return localPath
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+
+        } else {  // 중복 다운로드 동작일 경우
+            return localPath
+        }
+        return localPath
+    }
+}

--- a/Application/Project_Footprint/app/src/main/res/xml/filepaths.xml
+++ b/Application/Project_Footprint/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="storage/emulated" path="."/>
+</paths>


### PR DESCRIPTION
- HistoryDetailActivity.kt : 인스타그램의 피드, 스토리에 히스토리를 업로드할 수 있는 기능을 구현하였습니다.
- ImageDownloader.kt : 인스타그램의 정책상 외부 URL의 이미지를 공유할 수 없어서 요청 시 이미지를 서버에서 다운로드하여 해당 이미지의 URI를 인스타그램으로 보내도록 구현하였습니다.