### PR TITLE
[HyeonJun] 권한 예외 처리 분기 수정

### DIFF
--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/Website.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Network/Website.kt
@@ -4,6 +4,6 @@ package com.haerokim.project_footprint.Network
 
 class Website {
     companion object{
-        const val BASE_URL = "https://b4817f13eb97.ngrok.io"
+        const val BASE_URL = "https://4b865831003d.ngrok.io"
     }
 }

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Utility/ShowPlaceInfo.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Utility/ShowPlaceInfo.kt
@@ -27,7 +27,6 @@ import io.realm.RealmConfiguration
  *  - 주로 ForegroundService 에서 특정 장소를 스캔했을 때 호출됨
  **/
 class ShowPlaceInfo(var context: Context, var placeID: String) : Activity() {
-
     fun notifyInfo(mode: String?) {
         // Realm 사용을 위해 init() 필요
         Realm.init(context)


### PR DESCRIPTION
- HomeFragment.kt : 기존에 실수로 위치 권한이 없어도 Beacon 스캔 동작이 시작되는 로직이었어서 사용자의 혼동이 우려되어, 해당 분기문을 수정하였습니다. 이제 위치, 블루투스 권한 모두 허용되어야 Beacon 스캔 동작이 시작되고, 둘 중 하나라도 허용되지 않으면 오류 메세지를 발생합니다.