### PR TITLE
[HyeonJun] SurroundFragment 직관적인 UI 로 수정

### DIFF
--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Fragment/Home/HomeFragment.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Fragment/Home/HomeFragment.kt
@@ -223,6 +223,7 @@ class HomeFragment : Fragment(), PermissionListener {
 
         // 앱 재시작 후 UI 복원 시 마지막 Switch 상태로 복구 (SharedPreference)
         scanning_mode_switch.isChecked = switchStateSave.getBoolean("state", false)
+        viewModel.scanMode.value = switchStateSave.getBoolean("state", false)
 
         // 사용자 프로필 이미지 로드를 위한 SharedPreferences 객체
         val pref: SharedPreferences? =
@@ -332,7 +333,6 @@ class HomeFragment : Fragment(), PermissionListener {
 
     override fun onDestroy() {
         super.onDestroy()
-
 
     }
 }

--- a/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Fragment/SurroundPlace/SurroundFragment.kt
+++ b/Application/Project_Footprint/app/src/main/java/com/haerokim/project_footprint/Fragment/SurroundPlace/SurroundFragment.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.graphics.Color
 import android.os.AsyncTask
 import android.os.Bundle
 import android.util.Log
@@ -222,10 +223,13 @@ class SurroundFragment : Fragment() {
         }
 
         if (viewModel.scanMode.value == false) {
+            surround_place_banner.setBackgroundColor(Color.parseColor("#696969"))
             loading_spinner.visibility = View.GONE
             Toast.makeText(context, "발자취 따라가기를 활성화 해주세요", Toast.LENGTH_LONG).show()
             text_state.text = "발자취 따라가기를 활성화 해주세요"
+
         } else {
+            surround_place_banner.setBackgroundColor(Color.parseColor("#FF293263"))
             text_state.text = "가까운 주변 장소를 탐색합니다"
 
         }

--- a/Application/Project_Footprint/app/src/main/res/layout/fragment_surround.xml
+++ b/Application/Project_Footprint/app/src/main/res/layout/fragment_surround.xml
@@ -6,9 +6,10 @@
     tools:context=".Fragment.SurroundPlace.SurroundFragment">
 
     <ImageView
+        android:id="@+id/surround_place_banner"
         android:layout_width="match_parent"
         android:layout_height="230dp"
-        android:src="@color/colorPrimary"/>
+        android:background="@color/colorPrimary"/>
 
     <RelativeLayout
         android:id="@+id/status_banner"


### PR DESCRIPTION
- SurroundFragment.kt : Beacon 스캔 모드가 비활성화 되어 있으면 해당 레이아웃의 색깔을 회색으로 변경하여 사용자가 직관적으로 상태를 인지할 수 있도록 함
- HomeFragment.kt : onViewCreated() 에서 Switch 의 상태를 SharedPreferences 에서 값을 복구하도록 함